### PR TITLE
deps: Update the requirements for RBS::Inline to 0.11.0 or above

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ PATH
       railties
       rake
       rbs
-      rbs-inline
+      rbs-inline (>= 0.11.0)
 
 GEM
   remote: https://rubygems.org/
@@ -62,9 +62,9 @@ GEM
     diff-lcs (1.5.1)
     drb (2.2.1)
     erubi (1.13.0)
-    ffi (1.17.0)
-    ffi (1.17.0-x86_64-darwin)
-    ffi (1.17.0-x86_64-linux-gnu)
+    ffi (1.17.1)
+    ffi (1.17.1-x86_64-darwin)
+    ffi (1.17.1-x86_64-linux-gnu)
     fileutils (1.7.2)
     globalid (1.2.1)
       activesupport (>= 6.1)
@@ -79,7 +79,7 @@ GEM
     listen (3.9.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
-    logger (1.6.1)
+    logger (1.6.6)
     loofah (2.22.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
@@ -100,18 +100,18 @@ GEM
       timeout
     net-smtp (0.5.0)
       net-protocol
-    nokogiri (1.16.7)
+    nokogiri (1.18.3)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
-    nokogiri (1.16.7-x86_64-darwin)
+    nokogiri (1.18.3-x86_64-darwin)
       racc (~> 1.4)
-    nokogiri (1.16.7-x86_64-linux)
+    nokogiri (1.18.3-x86_64-linux-gnu)
       racc (~> 1.4)
     parallel (1.26.3)
     parser (3.3.5.0)
       ast (~> 2.4.1)
       racc
-    prism (1.0.0)
+    prism (1.2.0)
     psych (5.1.2)
       stringio
     racc (1.8.1)
@@ -145,8 +145,8 @@ GEM
       ffi (~> 1.0)
     rbs (3.6.1)
       logger
-    rbs-inline (0.9.0)
-      prism (>= 0.29, < 1.1)
+    rbs-inline (0.11.0)
+      prism (>= 0.29, < 1.3)
       rbs (>= 3.5.0)
     rdoc (6.7.0)
       psych (>= 4.0.0)

--- a/lib/rbs_actionmailer/generator.rb
+++ b/lib/rbs_actionmailer/generator.rb
@@ -80,7 +80,8 @@ module RbsActionmailer
 
       return ["*untyped"] unless member
 
-      member.method_overloads.map { |overload| overload.method_type.type.param_to_s }
+      untyped = RBS::Types::Bases::Any.new(location: nil)
+      member.method_overloads(untyped).map { |overload| overload.method_type.type.param_to_s }
     end
 
     def footer #: String

--- a/rbs_actionmailer.gemspec
+++ b/rbs_actionmailer.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "railties"
   spec.add_dependency "rake"
   spec.add_dependency "rbs"
-  spec.add_dependency "rbs-inline"
+  spec.add_dependency "rbs-inline", ">= 0.11.0"
 
   # For more information and examples about making a new gem, check out our
   # guide at: https://bundler.io/guides/creating_gem.html


### PR DESCRIPTION
The interface has been changed since rbs-inline-0.11.0.  So this follows the new interface to support the latest version of rbs-inline.