### PR TITLE
deps: bump required Ruby version to 3.1.0

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 3.1
 
 Metrics/AbcSize:
   Max: 20

--- a/lib/rbs_actionmailer/generator.rb
+++ b/lib/rbs_actionmailer/generator.rb
@@ -31,7 +31,7 @@ module RbsActionmailer
     def format(rbs) #: String
       parsed = RBS::Parser.parse_signature(rbs)
       StringIO.new.tap do |out|
-        RBS::Writer.new(out: out).write(parsed[1] + parsed[2])
+        RBS::Writer.new(out:).write(parsed[1] + parsed[2])
       end.string
     end
 

--- a/rbs_actionmailer.gemspec
+++ b/rbs_actionmailer.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.description = "A RBS files generator for ActionMailer"
   spec.homepage = "https://github.com/tk0miya/rbs_actionmailer"
   spec.license = "MIT"
-  spec.required_ruby_version = ">= 2.7.0"
+  spec.required_ruby_version = ">= 3.1.0"
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = spec.homepage


### PR DESCRIPTION
To follow the deps of RBS::Inline, this PR bumps the required Ruby version to 3.1.0.