### PR TITLE
Do not generate types for instance methods

### DIFF
--- a/lib/rbs_actionmailer/generator.rb
+++ b/lib/rbs_actionmailer/generator.rb
@@ -58,11 +58,9 @@ module RbsActionmailer
     def methods #: String
       klass.action_methods.sort.map do |method_name|
         arg_types = arguments_for(method_name)
-        singleton_method_types = arg_types.map { |args| "(#{args}) -> ActionMailer::MessageDelivery" }.join(" | ")
-        instance_method_types = arg_types.map { |args| "(#{args}) -> Mail::Message" }.join(" | ")
+        method_types = arg_types.map { |args| "(#{args}) -> ActionMailer::MessageDelivery" }.join(" | ")
         <<~RBS
-          def self.#{method_name}: #{singleton_method_types}
-          def #{method_name}: #{instance_method_types}
+          def self.#{method_name}: #{method_types}
         RBS
       end.join("\n")
     end

--- a/spec/rbs_actionmailer/generator_spec.rb
+++ b/spec/rbs_actionmailer/generator_spec.rb
@@ -19,17 +19,12 @@ RSpec.describe RbsActionmailer::Generator do
           class UserMailer < ::ActionMailer::Base
             def self.event: (User user, age: Integer) -> ActionMailer::MessageDelivery
                           | (User user, address: String) -> ActionMailer::MessageDelivery
-            def event: (User user, age: Integer) -> Mail::Message
-                     | (User user, address: String) -> Mail::Message
 
             def self.goodbye: (User user) -> ActionMailer::MessageDelivery
-            def goodbye: (User user) -> Mail::Message
 
             def self.greeting: (untyped user) -> ActionMailer::MessageDelivery
-            def greeting: (untyped user) -> Mail::Message
 
             def self.welcome: () -> ActionMailer::MessageDelivery
-            def welcome: () -> Mail::Message
           end
         end
       RBS


### PR DESCRIPTION
Usually, developers generate types for instance methods for mailer classes via RBS::Inline or similar tools.  Therefore, rbs_actionmailer should not generate types for the instance methods to avoid the conflicts.