### PR TITLE
ci: add zizmor and rename actionlint workflow to workflow-lint

### DIFF
--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -1,4 +1,4 @@
-name: actionlint
+name: Workflow lint
 
 on:
   push:
@@ -11,7 +11,7 @@ permissions:
   contents: read
 
 jobs:
-  lint:
+  actionlint:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -22,3 +22,13 @@ jobs:
       run: |
         bash <(curl -L https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
         ./actionlint -color
+
+  zizmor:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      with:
+        persist-credentials: false
+    - uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
+      with:
+        advanced-security: false


### PR DESCRIPTION
## Summary

Rename `.github/workflows/actionlint.yml` to `.github/workflows/workflow-lint.yml` and add a parallel `zizmor` job alongside the existing `actionlint` job.

Background: the recent `persist-credentials: false` work was triggered by a finding that `actionlint` does not catch. `zizmor` is a static analysis tool focused on GitHub Actions security and would have flagged that case (and others — unpinned uses, template injection, etc.).

### Layout choices

- **One file, two jobs**: actionlint and zizmor are both "workflow linters," so they live in the same file under a single `name: Workflow lint`. Jobs run in parallel, so wall-clock time is one job's worth.
- **`workflow-lint.yml`** as the filename: tool-agnostic, future-proof if we add `ghalint`/etc.
- **`advanced-security: false`** on `zizmor-action`: emit GitHub annotations + non-zero exit on findings, instead of uploading SARIF. Keeps the lint behavior "fail the CI on findings" without needing `security-events: write`.

Reference: https://github.com/zizmorcore/zizmor-action

## Test plan

- [x] `actionlint` still runs (renamed file, same content)
- [ ] New `zizmor` job runs to completion on this PR