### PR TITLE
ci: explain why bundler cache is disabled in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,10 @@ jobs:
         uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f # v1.310.0
         with:
           ruby-version: ruby
+          # Skip bundler cache to avoid the cache-poisoning attack at release time:
+          # a poisoned cache written from a PR could otherwise be reused here
+          # and end up shipped to RubyGems.
+          # See https://docs.zizmor.sh/audits/#cache-poisoning
           bundler-cache: false
       - name: Install dependencies
         run: bundle install


### PR DESCRIPTION
## Summary

Add an inline comment on `bundler-cache: false` in `release.yml` so that a future reader (or future-me) does not "fix" it back to `true` for the speed win without realising the security trade-off.

The previous PR (#163) disabled the cache to address `zizmor`'s `cache-poisoning` finding, but left no explanation in the file itself. This PR adds three short lines on top of the `bundler-cache: false` line: the attack it prevents, why release in particular is the risky place, and a link to the audit documentation.

No behavior change.

## Test plan

- [x] `actionlint` passes
- [x] YAML still parses (comment-only change)