### PR TITLE
ci: declare top-level permissions in workflows

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -7,6 +7,9 @@ on:
 
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -3,6 +3,9 @@ on:
   pull_request:
     types: [labeled]
 
+permissions:
+  contents: read
+
 jobs:
   auto-merge:
     runs-on: ubuntu-latest

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -3,8 +3,7 @@ on:
   pull_request:
     types: [labeled]
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   auto-merge:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,9 @@ on:
 
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/rbs_collection.yml
+++ b/.github/workflows/rbs_collection.yml
@@ -5,6 +5,9 @@ on:
     - cron: '00 8 * * MON'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Add an explicit top-level `permissions:` block to every workflow that did not already have one, so the workflow's default `GITHUB_TOKEN` is restricted to read-only access to repository contents.

Without an explicit declaration, GitHub falls back to the repository default token permissions, which can be much broader than what the workflow actually needs. Locking it down to `contents: read` at the top level means each job inherits that minimum and a future step cannot accidentally pick up write permissions just by being added to an existing workflow.

This addresses the `excessive-permissions` finding from `zizmor`.

### Per-workflow notes

- `auto-merge.yml`, `rbs_collection.yml`, `dependabot-auto-label.yml` — all write operations go through a separate GitHub App token (`actions/create-github-app-token`), so the workflow's `GITHUB_TOKEN` does not need any write permission. (`dependabot-auto-label.yml` already declares `pull-requests: read` because `dependabot/fetch-metadata` reads PR metadata via the default token.)
- `main.yml` — runs tests only; `contents: read` is enough.
- `actionlint.yml` — runs the linter on checked-out source; `contents: read` is enough.
- `release.yml` — already declares its own job-level permissions (`contents: write`, `id-token: write`) for `rubygems/release-gem`, so it is intentionally not changed here.

References:
- https://docs.zizmor.sh/audits/#excessive-permissions
- https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token

## Test plan

- [x] Run the affected workflows on this PR and confirm they still pass (CI on this PR exercises `actionlint.yml` and `main.yml`).