### PR TITLE
Add Bundler cooldown for newly published gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-source "https://rubygems.org"
+source "https://rubygems.org", cooldown: 7
 
 # Specify your gem's dependencies in rbs_actionmailer.gemspec
 gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -249,4 +249,4 @@ DEPENDENCIES
   steep
 
 BUNDLED WITH
-  4.0.9
+  4.0.15


### PR DESCRIPTION
## Summary

Adds a client-side Bundler cooldown so newly published gem versions are not resolved until they have been public for 7 days, complementing the existing Dependabot `cooldown` (which only protects Dependabot-authored update PRs) by also covering manual/local `bundle update` resolution. The 7-day window matches the Dependabot `default-days: 7` setting.

## Changes

- `Gemfile`: add `cooldown: 7` to the `source "https://rubygems.org"` line.
- `Gemfile.lock`: bump `BUNDLED WITH` to `4.0.15`. The `cooldown` option requires Bundler 4.0.13+; CI installs the bundler version pinned in the lockfile via `ruby/setup-ruby` with `bundler-cache: true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)