### PR TITLE
Add rbs:generate task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -17,6 +17,11 @@ namespace :rbs do
     sh "bundle exec rbs collection install --frozen"
   end
 
+  desc "Generate RBS files"
+  task :generate do
+    sh "rbs-inline", "--opt-out", "--output=sig", "lib"
+  end
+
   desc "Validate RBS files"
   task validate: "rbs:install" do
     sh "bundle exec rbs -Isig validate"


### PR DESCRIPTION
## Summary

Adds an `rbs:generate` task (`rbs-inline --opt-out --output=sig lib`) to match the `init-ruby-project` skeleton and the sibling `rbs_*` gems. This project generates its RBS signatures from rbs-inline annotations in `lib`, but the task was missed during the earlier CI consolidation (#185) because the rbs-inline dependency lives in the gemspec rather than the Gemfile.

## Changes

- `Rakefile`
  - add `rbs:generate` (`rbs-inline --opt-out --output=sig lib`)

## Notes

- `rbs:generate` is a manual, developer-facing task and is not part of the ci chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)