### PR TITLE
Enable the rubocop-rbs_inline plugin

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,9 @@
 AllCops:
   TargetRubyVersion: 3.1
 
+plugins:
+  - rubocop-rbs_inline
+
 Metrics/AbcSize:
   Max: 20
 
@@ -25,3 +28,12 @@ Style/AccessorGrouping:
 
 Style/CommentedKeyword:
   Enabled: false
+
+Style/RbsInline/MissingTypeAnnotation:
+  EnforcedStyle: doc_style_and_return_annotation
+
+Style/RbsInline/RedundantTypeAnnotation:
+  EnforcedStyle: doc_style_and_return_annotation
+
+Style/RbsInline/RequireRbsInlineComment:
+  EnforcedStyle: never

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -31,6 +31,9 @@ Style/CommentedKeyword:
 
 Style/RbsInline/MissingTypeAnnotation:
   EnforcedStyle: doc_style_and_return_annotation
+  Exclude:
+    # Fixtures intentionally include unannotated methods to exercise the generator.
+    - "spec/fixtures/**/*"
 
 Style/RbsInline/RedundantTypeAnnotation:
   EnforcedStyle: doc_style_and_return_annotation

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ source "https://rubygems.org", cooldown: 7
 gemspec
 
 gem "rubocop", "~> 1.88"
+gem "rubocop-rbs_inline"
 
 group :development do
   gem "rspec", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -201,6 +201,10 @@ GEM
     rubocop-ast (1.49.1)
       parser (>= 3.3.7.2)
       prism (~> 1.7)
+    rubocop-rbs_inline (1.5.5)
+      lint_roller (~> 1.1)
+      rbs-inline
+      rubocop (>= 1.72.1, < 2.0)
     ruby-progressbar (1.13.0)
     securerandom (0.4.1)
     steep (1.10.0)
@@ -246,6 +250,7 @@ DEPENDENCIES
   rspec
   rspec-daemon
   rubocop (~> 1.88)
+  rubocop-rbs_inline
   steep
 
 BUNDLED WITH

--- a/lib/generators/rbs_actionmailer/install_generator.rb
+++ b/lib/generators/rbs_actionmailer/install_generator.rb
@@ -2,7 +2,7 @@
 
 module RbsActionmailer
   class InstallGenerator < Rails::Generators::Base
-    def create_raketask
+    def create_raketask #: void
       create_file "lib/tasks/rbs_actionmailer.rake", <<~RUBY
         # frozen_string_literal: true
 

--- a/sig/generators/rbs_actionmailer/install_generator.rbs
+++ b/sig/generators/rbs_actionmailer/install_generator.rbs
@@ -2,6 +2,6 @@
 
 module RbsActionmailer
   class InstallGenerator < Rails::Generators::Base
-    def create_raketask: () -> untyped
+    def create_raketask: () -> void
   end
 end


### PR DESCRIPTION
## Summary

This gem uses rbs-inline annotations in `lib` but did not lint them. Adds the `rubocop-rbs_inline` RuboCop plugin (and its cop configuration) to match the `init-ruby-project` skeleton, so the inline type annotations are checked by `rake rubocop` / `rake ci`.

## Changes

- `Gemfile` / `Gemfile.lock`: add `rubocop-rbs_inline`
- `.rubocop.yml`
  - add a `plugins` section with `rubocop-rbs_inline`
  - add `Style/RbsInline/*` settings (matching the skeleton)

🤖 Generated with [Claude Code](https://claude.com/claude-code)