### PR TITLE
Introduce rubocop-numbered-params

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,6 +2,7 @@ AllCops:
   TargetRubyVersion: 3.1
 
 plugins:
+  - rubocop-numbered-params
   - rubocop-rbs_inline
 
 Metrics/AbcSize:

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ source "https://rubygems.org", cooldown: 7
 gemspec
 
 gem "rubocop", "~> 1.88"
+gem "rubocop-numbered-params"
 gem "rubocop-rbs_inline"
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -201,6 +201,9 @@ GEM
     rubocop-ast (1.49.1)
       parser (>= 3.3.7.2)
       prism (~> 1.7)
+    rubocop-numbered-params (1.0.0)
+      lint_roller (~> 1.0)
+      rubocop (>= 1.72.1)
     rubocop-rbs_inline (1.5.5)
       lint_roller (~> 1.1)
       rbs-inline
@@ -250,6 +253,7 @@ DEPENDENCIES
   rspec
   rspec-daemon
   rubocop (~> 1.88)
+  rubocop-numbered-params
   rubocop-rbs_inline
   steep
 

--- a/lib/rbs_actionmailer/generator.rb
+++ b/lib/rbs_actionmailer/generator.rb
@@ -58,7 +58,7 @@ module RbsActionmailer
     def methods #: String
       klass.action_methods.sort.map do |method_name|
         arg_types = arguments_for(method_name)
-        method_types = arg_types.map { |args| "(#{args}) -> ActionMailer::MessageDelivery" }.join(" | ")
+        method_types = arg_types.map { "(#{_1}) -> ActionMailer::MessageDelivery" }.join(" | ")
         <<~RBS
           def self.#{method_name}: #{method_types}
         RBS
@@ -79,7 +79,7 @@ module RbsActionmailer
       return ["*untyped"] unless member
 
       untyped = RBS::Types::Bases::Any.new(location: nil)
-      member.method_overloads(untyped).map { |overload| overload.method_type.type.param_to_s }
+      member.method_overloads(untyped).map { _1.method_type.type.param_to_s }
     end
 
     def footer #: String

--- a/rbs_actionmailer.gemspec
+++ b/rbs_actionmailer.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
     end
   end
   spec.bindir = "exe"
-  spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
+  spec.executables = spec.files.grep(%r{\Aexe/}) { File.basename(_1) }
   spec.require_paths = ["lib"]
 
   spec.add_dependency "actionmailer"


### PR DESCRIPTION
Add the `rubocop-numbered-params` plugin to enforce a consistent style for numbered block parameters, matching the setup already used in other repositories.

- Add `rubocop-numbered-params` to the Gemfile and Gemfile.lock
- Register the plugin in `.rubocop.yml`
- Autocorrect existing offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)