### PR TITLE
Introduce rubocop-rspec plugin

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,12 +5,22 @@ plugins:
   - rubocop-numbered-params
   - rubocop-rake
   - rubocop-rbs_inline
+  - rubocop-rspec
 
 Metrics/AbcSize:
   Max: 20
 
 Metrics/MethodLength:
   Max: 20
+
+RSpec/MultipleExpectations:
+  Enabled: false
+
+RSpec/NamedSubject:
+  Enabled: false
+
+RSpec/NestedGroups:
+  Max: 5
 
 Style/Documentation:
   Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem "rubocop", "~> 1.88"
 gem "rubocop-numbered-params"
 gem "rubocop-rake"
 gem "rubocop-rbs_inline"
+gem "rubocop-rspec"
 
 group :development do
   gem "rspec", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -211,6 +211,10 @@ GEM
       lint_roller (~> 1.1)
       rbs-inline
       rubocop (>= 1.72.1, < 2.0)
+    rubocop-rspec (3.10.2)
+      lint_roller (~> 1.1)
+      regexp_parser (>= 2.0)
+      rubocop (~> 1.86, >= 1.86.2)
     ruby-progressbar (1.13.0)
     securerandom (0.4.1)
     steep (1.10.0)
@@ -259,6 +263,7 @@ DEPENDENCIES
   rubocop-numbered-params
   rubocop-rake
   rubocop-rbs_inline
+  rubocop-rspec
   steep
 
 BUNDLED WITH

--- a/spec/rbs_actionmailer/parser_spec.rb
+++ b/spec/rbs_actionmailer/parser_spec.rb
@@ -7,14 +7,14 @@ RSpec.describe RbsActionmailer::Parser do
   describe ".parse" do
     subject { described_class.parse(klass_name) }
 
-    context "When non-existing klass_name given" do
+    context "when non-existing klass_name given" do
       let(:klass_name) { "UnknownModule" }
 
-      it { is_expected.to be nil }
+      it { is_expected.to be_nil }
     end
 
-    context "When existing klass_name given" do
-      context "When the klass_name is shallow" do
+    context "when existing klass_name given" do
+      context "when the klass_name is shallow" do
         let(:klass_name) { "Mod" }
 
         it "Returns a target module" do
@@ -23,7 +23,7 @@ RSpec.describe RbsActionmailer::Parser do
         end
       end
 
-      context "When the klass_name is deep" do
+      context "when the klass_name is deep" do
         let(:klass_name) { "Mod::UserMailer" }
 
         it "Returns a target class" do


### PR DESCRIPTION
Add the `rubocop-rspec` plugin so this repository lints its specs, completing the full plugin set (numbered-params, rake, rbs_inline, rspec) shared across the sibling repositories.

- Add `rubocop-rspec` to the Gemfile and lockfile
- Register it under `plugins:` in `.rubocop.yml`
- Configure `RSpec/NamedSubject`, `RSpec/MultipleExpectations`, and `RSpec/NestedGroups` with the same settings used across the sibling repositories
- Reword `context` descriptions to lowercase `when …` to satisfy `RSpec/ContextWording` (matching the sibling specs)
- Autocorrect `be(nil)` to `be_nil` (`RSpec/BeNil`)

`rubocop` reports no offenses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)