### PR TITLE
Align .rubocop.yml with shared skeleton baseline

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,7 @@
+# NOTE: Rules are sorted in ASCII order.
+
 AllCops:
+  NewCops: enable
   TargetRubyVersion: 3.1
 
 plugins:
@@ -7,11 +10,34 @@ plugins:
   - rubocop-rbs_inline
   - rubocop-rspec
 
+# Layout
+Layout/LeadingCommentSpace:
+  AllowRBSInlineAnnotation: true
+  AllowSteepAnnotation: true
+
+Layout/LineLength:
+  Max: 120
+
+# Metrics
 Metrics/AbcSize:
   Max: 20
 
+Metrics/BlockLength:
+  Exclude:
+    - "spec/**/*_spec.rb"
+
+Metrics/ClassLength:
+  Max: 200
+
 Metrics/MethodLength:
-  Max: 20
+  Max: 30
+
+# RSpec
+RSpec/ExampleLength:
+  Enabled: false
+
+RSpec/MultipleMemoizedHelpers:
+  Max: 10
 
 RSpec/MultipleExpectations:
   Enabled: false
@@ -22,25 +48,7 @@ RSpec/NamedSubject:
 RSpec/NestedGroups:
   Max: 5
 
-Style/Documentation:
-  Enabled: false
-
-Style/StringLiterals:
-  EnforcedStyle: double_quotes
-
-Style/StringLiteralsInInterpolation:
-  EnforcedStyle: double_quotes
-
-# for RBS::Inline
-Layout/LeadingCommentSpace:
-  Enabled: false
-
-Style/AccessorGrouping:
-  Enabled: false
-
-Style/CommentedKeyword:
-  Enabled: false
-
+# RbsInline
 Style/RbsInline/MissingTypeAnnotation:
   EnforcedStyle: doc_style_and_return_annotation
   Exclude:
@@ -52,3 +60,25 @@ Style/RbsInline/RedundantTypeAnnotation:
 
 Style/RbsInline/RequireRbsInlineComment:
   EnforcedStyle: never
+
+# Style
+Style/AccessorGrouping:
+  Enabled: false
+
+Style/CommentedKeyword:
+  Enabled: false
+
+Style/Documentation:
+  Enabled: false
+
+Style/HashSyntax:
+  EnforcedShorthandSyntax: always
+
+Style/RedundantFormat:
+  Enabled: false
+
+Style/StringLiterals:
+  EnforcedStyle: double_quotes
+
+Style/StringLiteralsInInterpolation:
+  EnforcedStyle: double_quotes

--- a/lib/rbs_actionmailer/rake_task.rb
+++ b/lib/rbs_actionmailer/rake_task.rb
@@ -10,7 +10,7 @@ module RbsActionmailer
 
     # @rbs name: Symbol
     # @rbs &block: ?(self) -> void
-    def initialize(name = :'rbs:actionmailer', &block) #: void
+    def initialize(name = :"rbs:actionmailer", &block) #: void
       super()
 
       @name = name

--- a/rbs_actionmailer.gemspec
+++ b/rbs_actionmailer.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |spec|
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = spec.homepage
   spec.metadata["changelog_uri"] = spec.homepage
+  spec.metadata["rubygems_mfa_required"] = "true"
 
   gemspec = File.basename(__FILE__)
   spec.files = IO.popen(%w[git ls-files -z], chdir: __dir__, err: IO::NULL) do |ls|


### PR DESCRIPTION
## Summary

Align this repository's `.rubocop.yml` with the shared `init-ruby-project`
skeleton so linting rules are consistent across all Ruby repositories, and
fix the offenses the aligned config surfaces.

## Config changes

- Fill in missing cops: `AllCops/NewCops`, `Layout/LineLength`,
  `Metrics/BlockLength`, `Metrics/ClassLength`, `RSpec/ExampleLength`,
  `RSpec/MultipleMemoizedHelpers`, `Style/HashSyntax`
- `Metrics/MethodLength`: 20 → 30 (match baseline)
- Enable `Layout/LeadingCommentSpace` with RBS/Steep allowances instead of
  disabling it outright
- Rules sorted in ASCII order to match the skeleton

## Code changes (offenses surfaced by the new cops)

- `rake_task.rb`: use a double-quoted symbol
- `rbs_actionmailer.gemspec`: set `rubygems_mfa_required`
- Disable `Style/RedundantFormat`: the local `format` method is not
  `Kernel#format`, so the cop is a false positive here

Verified locally with `rubocop` (no offenses).

🤖 Generated with [Claude Code](https://claude.com/claude-code)