### PR TITLE
Bump rubocop-rbs_inline to 1.6.0 and drop RbsInline Exclude

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -51,9 +51,6 @@ RSpec/NestedGroups:
 # RbsInline
 Style/RbsInline/MissingTypeAnnotation:
   EnforcedStyle: doc_style_and_return_annotation
-  Exclude:
-    # Fixtures intentionally include unannotated methods to exercise the generator.
-    - "spec/fixtures/**/*"
 
 Style/RbsInline/RedundantTypeAnnotation:
   EnforcedStyle: doc_style_and_return_annotation

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -207,7 +207,7 @@ GEM
     rubocop-rake (0.7.1)
       lint_roller (~> 1.1)
       rubocop (>= 1.72.1)
-    rubocop-rbs_inline (1.5.5)
+    rubocop-rbs_inline (1.6.0)
       lint_roller (~> 1.1)
       rbs-inline
       rubocop (>= 1.72.1, < 2.0)


### PR DESCRIPTION
## Summary

`rubocop-rbs_inline` 1.6.0 no longer reports the fixtures that
`Style/RbsInline/MissingTypeAnnotation` used to flag, so the
`spec/fixtures/**/*` Exclude is no longer necessary.

## Changes

- `Gemfile.lock`: `rubocop-rbs_inline` 1.5.5 → 1.6.0
- `.rubocop.yml`: remove the `Style/RbsInline/MissingTypeAnnotation` Exclude

The `cooldown: 7` source option is unchanged (it was only relaxed
temporarily to pull the freshly released 1.6.0 into the lockfile).

🤖 Generated with [Claude Code](https://claude.com/claude-code)